### PR TITLE
Draw depth figure

### DIFF
--- a/evaluate/compare_depth_main.py
+++ b/evaluate/compare_depth_main.py
@@ -11,6 +11,7 @@ from config import opts
 
 MD1_FILE = "/media/ri-bear/IntHDD/vode_data/vode_0103/othermethod/monodepth/disparities_city2eigen_resnet/disparities_pp.npy"
 MD2_FILE = "/media/ri-bear/IntHDD/vode_data/vode_0103/othermethod/monodepth2/mono+stereo_1024x320_eigen.npy"
+RAW_IMAGE_RES = {"kitti_raw": (375, 1242)}
 
 
 def visualize_depth(ckpt_name, dataset_name="kitti_raw"):
@@ -19,44 +20,44 @@ def visualize_depth(ckpt_name, dataset_name="kitti_raw"):
     images = pred_data["image"]
     datlen, height, width, _ = images.shape
     evaldata = dict()
-    evaldata["depth_md1"] = 1. / (np.load(MD1_FILE) + 1e-6)
-    evaldata["depth_md2"] = 1. / (np.load(MD2_FILE) + 1e-6)
-    evaldata["depth_xpt"] = pred_data["depth"]
+    evaldata["disp_md1"] = np.load(MD1_FILE)
+    evaldata["disp_md2"] = np.load(MD2_FILE)
+    disp = pred_data["depth"].copy()
+    disp[disp > 0] = 1 / disp[disp > 0]
+    evaldata["disp_xpt"] = disp
+
     dirname = op.join(opts.DATAPATH_EVL, ckpt_name, "comparison")
     os.makedirs(dirname, exist_ok=True)
-
-    max_disp = 2.5
+    depth_res = opts.IMAGE_SIZES[dataset_name]
+    rawimg_res = RAW_IMAGE_RES[dataset_name]
 
     for i in range(datlen):
         image = images[i]
         result = [image]
 
-        for key, depths in evaldata.items():
-            depth = depths[i]
-            # print("eval data:", i, key, depth.shape)
-            if key == "depth_gt":
-                depth = fill_zero_depth(depth)
-                depth = fill_zero_depth(depth)
+        for key, disps in evaldata.items():
+            disp = disps[i]
+            if disp.shape[:2] != depth_res:
+                # resize with keeping raw image aspect ratio
+                rsz_height = round(rawimg_res[0] / rawimg_res[1] * depth_res[1])
+                disp = cv2.resize(disp, (depth_res[1], rsz_height))
+                # crop top and bottom to fit with our result
+                top = round((rsz_height - depth_res[0]) / 3. * 2.)
+                bot = round((rsz_height - depth_res[0]) / 3.)
+                disp = disp[top:-bot]
 
-            # disp = 1. / (depth + 1e-6)
-            disp = depth.copy()
-            disp[depth > 0] = 1 / depth[depth > 0]
-            if disp.shape[:2] != (128, 512):
-                disp = cv2.resize(disp, (512, 155))
-                disp = disp[18:-9]
-
-            scale = np.mean(disp[-50:, 128:-128])
-            disp = disp / scale
+            max_disp = np.quantile(disp[-50:, 128:-128], [0.9])[0] * 1.1
+            # print("max_disp:", i, key, max_disp)
             disp = np.clip(disp, 0, max_disp)
             disp = (disp / max_disp * 255).astype(np.uint8)
             disp_color = cv2.applyColorMap(disp, cv2.COLORMAP_MAGMA)
             result.append(disp_color)
 
         result = np.concatenate(result, axis=0)
-        result[128:-2:128] = 0
+        result[depth_res[0]:-2:depth_res[0]] = 0
         cv2.imwrite(op.join(dirname, f"compare_{i:03d}.png"), result)
         cv2.imshow("result", result)
-        cv2.waitKey()
+        cv2.waitKey(50)
 
 
 def fill_zero_depth(depth):
@@ -89,4 +90,5 @@ def show_images(images):
 
 
 if __name__ == "__main__":
-    visualize_depth("vode28_static_comb", "kitti_raw")
+    # visualize_depth("vode28_static_comb", "kitti_raw")
+    visualize_depth("vode30_t2_comb", "kitti_raw")

--- a/evaluate/draw_depth_main.py
+++ b/evaluate/draw_depth_main.py
@@ -21,6 +21,13 @@ def visualize_depth(ckpt_name, dataset_name="kitti_raw"):
     # print("monodepth disp max", np.max(depth_md1), np.max(depth_md2))
     # print("monodepth dept max", np.max(1 / (depth_md1 + 1e-6)), np.max(1 / (depth_md2 + 1e-6)))
 
+    def close_event():
+        plt.close()  # timer calls this function after 3 seconds and closes the window
+
+    fig = plt.figure()
+    timer = fig.canvas.new_timer(interval=500)  # creating a timer object and setting an interval of 3000 milliseconds
+    timer.add_callback(close_event)
+
     for i in range(datlen):
         image = evaldata["image"][i]
         depth_gt = evaldata["depth_gt"][i]
@@ -28,10 +35,14 @@ def visualize_depth(ckpt_name, dataset_name="kitti_raw"):
         for k in range(3):
             depth_fill = fill_zero_depth(depth_fill)
         depth_pr = evaldata["depth"][i]
+        print("--- eval depth:", i)
+        if i < 38:
+            continue
         
         plt.rcParams["figure.figsize"] = (6, 10)
-        show_images([image, depth_gt, depth_fill, depth_pr, depth_md1[i], depth_md2[i]])
+        show_images([image, depth_fill, depth_pr, depth_md1[i], depth_md2[i]])
         plt.subplots_adjust(top=0.99, bottom=0.01, left=0.1, right=0.9, hspace=-0.35)
+        # timer.start()
         plt.show()
 
 

--- a/evaluate/draw_depth_main.py
+++ b/evaluate/draw_depth_main.py
@@ -1,0 +1,68 @@
+import os.path as op
+import cv2
+import numpy as np
+import matplotlib
+matplotlib.use('TkAgg')
+import matplotlib.pyplot as plt
+
+import settings
+from config import opts
+
+MD1_FILE = "/media/ri-bear/IntHDD/vode_data/vode_0103/othermethod/monodepth/disparities_city2eigen_resnet/disparities_pp.npy"
+MD2_FILE = "/media/ri-bear/IntHDD/vode_data/vode_0103/othermethod/monodepth2/mono+stereo_1024x320_eigen.npy"
+
+
+def visualize_depth(ckpt_name, dataset_name="kitti_raw"):
+    evaldata = np.load(op.join(opts.DATAPATH_PRD, ckpt_name, dataset_name + "_latest.npz"))
+    datlen = evaldata["image"].shape[0]
+    depth_md1 = 1. / (np.load(MD1_FILE) + 1e-6)
+    depth_md2 = 1. / (np.load(MD2_FILE) + 1e-6)
+    print("monodepth shape", depth_md1.shape, depth_md2.shape)
+    # print("monodepth disp max", np.max(depth_md1), np.max(depth_md2))
+    # print("monodepth dept max", np.max(1 / (depth_md1 + 1e-6)), np.max(1 / (depth_md2 + 1e-6)))
+
+    for i in range(datlen):
+        image = evaldata["image"][i]
+        depth_gt = evaldata["depth_gt"][i]
+        depth_fill = depth_gt.copy()
+        for k in range(3):
+            depth_fill = fill_zero_depth(depth_fill)
+        depth_pr = evaldata["depth"][i]
+        
+        plt.rcParams["figure.figsize"] = (6, 10)
+        show_images([image, depth_gt, depth_fill, depth_pr, depth_md1[i], depth_md2[i]])
+        plt.subplots_adjust(top=0.99, bottom=0.01, left=0.1, right=0.9, hspace=-0.35)
+        plt.show()
+
+
+def fill_zero_depth(depth):
+    if depth.ndim == 3:
+        depth = depth[..., 0]
+    # add 3x3 neighbor pixels
+    nei_depths = np.zeros((depth.shape[0], depth.shape[1], 9), dtype=np.float32)
+    nei_depths[:-1, :-1, 0] += depth[1:, 1:]
+    nei_depths[:-1, :, 1] += depth[1:, :]
+    nei_depths[:-1, 1:, 2] += depth[1:, :-1]
+    nei_depths[:, :-1, 3] += depth[:, 1:]
+    nei_depths[:, :, 4] += depth[:, :]
+    nei_depths[:, 1:, 5] += depth[:, :-1]
+    nei_depths[1:, :-1, 6] += depth[:-1, 1:]
+    nei_depths[1:, :, 7] += depth[:-1, :]
+    nei_depths[1:, 1:, 8] += depth[:-1, :-1]
+    depth_new = np.sum(nei_depths, axis=-1)
+    valid_cnt = np.sum(nei_depths > 0, axis=-1)
+    depth_new = depth_new / (valid_cnt + 1e-6)
+    depth_new[depth > 0] = depth[depth > 0]
+    return depth_new
+
+
+def show_images(images):
+    for i, image in enumerate(images):
+        ax = plt.subplot(len(images), 1, i+1)
+        plt.imshow(image)
+        ax.axes.xaxis.set_visible(False)
+        ax.axes.yaxis.set_visible(False)
+
+
+if __name__ == "__main__":
+    visualize_depth("vode28_static_comb", "kitti_raw")

--- a/evaluate/evaluate_main.py
+++ b/evaluate/evaluate_main.py
@@ -19,11 +19,16 @@ def evaluate_by_plan():
 def evaluate_dataset(dataset_name, ckpt_name, weight_suffix):
     eval_dir_path = op.join(opts.DATAPATH_EVL, ckpt_name)
     if op.isdir(eval_dir_path):
-        print("\n[evaluate_dataset] evaluation was made in:", eval_dir_path)
+        print("\n[evaluate_dataset] evaluation has already been made in:", eval_dir_path)
+        return
+
+    filename = op.join(opts.DATAPATH_PRD, ckpt_name, f"{dataset_name}_{weight_suffix}.npz")
+    if not op.isfile(filename):
+        print("!!! [evaluate_dataset] no file:", filename)
         return
 
     with uc.PathManager([eval_dir_path], None) as pm:
-        filename = op.join(opts.DATAPATH_PRD, ckpt_name, f"{dataset_name}_{weight_suffix}.npz")
+        print(f"==== Start evaluation from {filename.replace(opts.DATAPATH, '')} to {eval_dir_path.replace(opts.DATAPATH, '')}")
         results = np.load(filename)
         results = {key: results[key] for key in results.files}
 

--- a/model/build_model/model_wrappers.py
+++ b/model/build_model/model_wrappers.py
@@ -52,8 +52,8 @@ class ModelWrapper:
 
     def append_outputs(self, features, predictions, outputs, suffix=""):
         image = features["image5d" + suffix]
-        target_ind = image.shape[1] // 2
-        image = tf.image.convert_image_dtype((image[:, target_ind] + 1.) / 2., dtype=tf.uint8)
+        # target image is at end
+        image = tf.image.convert_image_dtype((image[:, -1] + 1.) / 2., dtype=tf.uint8)
         outputs["image" + suffix].append(image)
         if "pose" + suffix in outputs:
             # [batch, numsrc, 6]

--- a/model/build_model/model_wrappers.py
+++ b/model/build_model/model_wrappers.py
@@ -31,7 +31,8 @@ class ModelWrapper:
         return results
 
     def init_output_structure(self, keys):
-        outputs = {key: [] for key in keys}
+        outputs = {"image": []}
+        outputs.update({key: [] for key in keys})
         outputs.update({key + "_gt": [] for key in keys})
         if "depth" in keys:
             outputs["intrinsic"] = []
@@ -50,6 +51,10 @@ class ModelWrapper:
         return predictions
 
     def append_outputs(self, features, predictions, outputs, suffix=""):
+        image = features["image5d" + suffix]
+        target_ind = image.shape[1] // 2
+        image = tf.image.convert_image_dtype((image[:, target_ind] + 1.) / 2., dtype=tf.uint8)
+        outputs["image" + suffix].append(image)
         if "pose" + suffix in outputs:
             # [batch, numsrc, 6]
             pose_gt = features["pose_gt" + suffix]

--- a/model/build_model/model_wrappers.py
+++ b/model/build_model/model_wrappers.py
@@ -110,6 +110,8 @@ class ModelWrapper:
             if op.isfile(ckpt_file):
                 self.models[netname].load_weights(ckpt_file)
                 print(f"===== {netname} weights loaded from", ckpt_file)
+                num_params = tf.reduce_sum([tf.reduce_prod(v.shape) for v in self.models[netname].trainable_variables])
+                print(f"      {netname} num params:", num_params)
             else:
                 print(f"===== Failed to load weights of {netname}, train from scratch ...")
                 print(f"      tried to load file:", ckpt_file)

--- a/model/build_model/pose_net.py
+++ b/model/build_model/pose_net.py
@@ -41,7 +41,6 @@ class PoseNetBasic:
                                       name="channel_stack")(input_tensor)
         return input_tensor, posenet_input
 
-
     def restack_on_channels(self, image5d):
         batch, snippet, height, width, channel = self.input_shape
         # transpose image: [batch, snippet, height, width, channel] -> [batch, height, width, snippet, channel]

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -88,9 +88,7 @@ def create_training_parts(initial_epoch, tfr_config, learning_rate, loss_weights
     # during joint training, flownet is frozen
     if ("depth" in net_names) and ("flow" in net_names):
         model.set_trainable("flownet", False)
-        # model.set_trainable("depthnet", False)
 
-    # model.compile(optimizer='sgd', loss='mean_absolute_error')
     augmenter = augmentation_factory(opts.AUGMENT_PROBS)
     loss_object = loss_factory(tfr_config, loss_weights, scale_weights,
                                weights_to_regularize=model.weights_to_regularize())
@@ -162,6 +160,18 @@ def save_predictions(results, ckpt_name, dataset_name, weight_suffix):
     np.savez(pred_path, **results)
 
 
+def log_images():
+    set_configs()
+    net_names, dataset_name = opts.JOINT_NET, "kitti_raw"
+    dataset_val, tfr_config, val_steps = get_dataset(dataset_name, "val", False)
+    model = ModelFactory(tfr_config, net_names=net_names, global_batch=opts.BATCH_SIZE, pretrained_weight=False).get_model()
+    model = try_load_weights(model, opts.CKPT_NAME, "latest")
+
+    print(f"\n\n========== START IMAGE LOGGING ON {opts.CKPT_NAME} ==========")
+    log.save_reconstruction_samples(model, dataset_val, val_steps, 100)
+
+
+
 # ==================== tests ====================
 
 def test_model_wrapper_output():
@@ -198,6 +208,7 @@ def test_npz():
 
 
 if __name__ == "__main__":
-    # train_by_plan(opts.TRAINING_PLAN)
-    predict_by_plan()
+    train_by_plan(opts.TRAINING_PLAN)
+    # predict_by_plan()
+    # log_images()
 

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -144,7 +144,7 @@ def predict(net_names, dataset_name, save_keys, ckpt_name, weight_suffix):
         return
 
     with uc.PathManager([pred_dir_path], None) as pm:
-        dataset, tfr_config, steps = get_dataset(dataset_name, "test", True)
+        dataset, tfr_config, steps = get_dataset(dataset_name, "test", False)
         model = ModelFactory(tfr_config, net_names=net_names).get_model()
         model = try_load_weights(model, ckpt_name, weight_suffix)
         results = model.predict_dataset(dataset, save_keys, steps)
@@ -198,6 +198,6 @@ def test_npz():
 
 
 if __name__ == "__main__":
-    train_by_plan(opts.TRAINING_PLAN)
-    # predict_by_plan()
+    # train_by_plan(opts.TRAINING_PLAN)
+    predict_by_plan()
 

--- a/tfrecords/example_maker.py
+++ b/tfrecords/example_maker.py
@@ -53,7 +53,8 @@ class ExampleMaker:
         frame_id, frame_seq_ids = self.make_snippet_ids(index)
         example = dict()
         example["image"], rawshape_hw, rszshape_hw = self.load_snippet_images(frame_seq_ids)
-        self.check_static_sequence(example)
+        if self.split != "test":
+            self.check_static_sequence(example)
 
         example["intrinsic"] = self.load_intrinsic(frame_id, rawshape_hw, rszshape_hw)
         if "depth_gt" in self.data_keys:

--- a/tfrecords/example_maker.py
+++ b/tfrecords/example_maker.py
@@ -20,12 +20,13 @@ class ExampleMaker:
         self.data_reader = WaymoReader()
         self.reader_args = reader_args
         self.max_frame_id = 0
+        self.example_count = 0
 
     def init_reader(self, drive_path):
         self.data_reader = self.data_reader_factory()
         self.data_reader.init_drive(drive_path)
         if len(self.get_range()) > 0:
-            self.max_frame_id = self.get_range()[-1]
+            self.max_frame_id = max(self.get_range())
 
     def data_reader_factory(self):
         if self.dataset == "kitti_raw":
@@ -56,6 +57,8 @@ class ExampleMaker:
         if self.split != "test":
             self.check_static_sequence(example)
 
+        self.example_count += 1
+
         example["intrinsic"] = self.load_intrinsic(frame_id, rawshape_hw, rszshape_hw)
         if "depth_gt" in self.data_keys:
             example["depth_gt"] = self.load_depth_map(frame_id, rawshape_hw, rszshape_hw)
@@ -83,13 +86,15 @@ class ExampleMaker:
             show_example(example, 200, print_param=True, max_height=0, suffix="_crop")
         elif index % 100 == 10:
             show_example(example, 200, max_height=0, suffix="_crop")
+        # elif self.example_count > 36:
+        #     print("self.example_count:", self.example_count, index, frame_id, frame_seq_ids)
+        #     show_example(example, 0, max_height=0, suffix="_crop")
         example = self.verify_snippet(example)
         return example
 
     def make_snippet_ids(self, frame_index):
         frame_id = self.data_reader.index_to_id(frame_index)
         halflen = self.shwc_shape[0] // 2
-        # max_frame_id = list(self.get_range())[-1]
         if (self.dataset == "a2d2") or (self.dataset.startswith("cityscapes")):
             frame_seq_ids = np.arange(frame_id-halflen*2, frame_id+halflen*2+1, 2)
         else:

--- a/tfrecords/readers/kitti_reader.py
+++ b/tfrecords/readers/kitti_reader.py
@@ -72,10 +72,12 @@ class KittiRawReader(DataReaderBase):
         velo_file = self.drive_loader.velo_files[index]
         velo_index = int(op.basename(velo_file)[:-4])
         if index != velo_index:
-            index_file = [file for file in self.drive_loader.velo_files if file.endswith(f"{index:010d}.bin")]
-            if index_file:
-                velo_index = int(op.basename(index_file[0])[:-4])
-                print(f"---[get_point_cloud] replace index {index} to {velo_index}")
+            # NOTE: velodyne indices are misaligned with camera indices in sequence ('2011_09_26', '0009')
+            # 'index-4' is empirically determined
+            index_files = [file for file in self.drive_loader.velo_files if file.endswith(f"{index-4:010d}.bin")]
+            print(f"\n---[get_point_cloud] different camera-lidar index:", index, velo_index, op.basename(velo_file), "find:", op.basename(index_files[0]))
+            if index_files:
+                velo_index = int(op.basename(index_files[0])[:-4])
             else:
                 raise MyExceptionToCatch(f"[get_point_cloud] no velodyne file for index {index}")
 

--- a/tfrecords/tfrecord_maker.py
+++ b/tfrecords/tfrecord_maker.py
@@ -208,7 +208,6 @@ class KittiRawTfrecordMaker(TfrecordMakerSingleDir):
         return ExampleMaker(dataset, split, shwc_shape, data_keys, self.srcpath)
 
     def list_drive_paths(self, srcpath, split):
-        # create drive paths like : ("2011_09_26", "0001")
         split_ = "train" if split == "train" else "test"
         code_tfrecord_path = op.dirname(op.abspath(__file__))
         filename = op.join(code_tfrecord_path, "resources", f"kitti_raw_{split_}_scenes.txt")


### PR DESCRIPTION
## compare_depth_main.py
- 내 모델과 다른 모델(monodepth1, 2)의 disparity map 비교하는 그림 만들어 파일로 저장

## model_main.py
- log_images() 구현: 학습안하고 이미지 로깅만 하는 함수

## save_reconstruction_samples
- optical flow까지 이미지로 만들어 저장

## kitti_reader.py
- KittiRawReader에서 이미지와 velodyne 파일명의 번호는 같은데 파일명 리스트에서 이름이 다를때 버리지 않고 해당 velodyne 파일 인덱스 찾아서 불러오기

